### PR TITLE
feat(aws): migrate away from static AWS IAM credentials (#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,6 @@ on:
         required: true
       OBSERVE_DOMAIN:
         required: false
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      AWS_SESSION_TOKEN:
-        required: false
-      AWS_REGION:
-        required: false
 
 env:
   USER: gha-${{ github.run_id }}
@@ -139,12 +131,14 @@ jobs:
     if: needs.permission_check.outputs.can-write == 'true'
     name: test ${{ matrix.provider }}
 
+    permissions:
+      contents: write
+      id-token: write
+
     env:
       OBSERVE_CUSTOMER: ${{ secrets.OBSERVE_CUSTOMER }}
       OBSERVE_TOKEN: ${{ secrets.OBSERVE_TOKEN }}
       OBSERVE_DOMAIN: ${{ secrets.OBSERVE_DOMAIN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       IMAGE_NAME: ${{ needs.build.outputs.image_name }}
 
     strategy:
@@ -223,7 +217,12 @@ jobs:
           sleep 120
           attempts=$((attempts + 1))
         done
-    
+
+    - name: Setup AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: us-west-2
 
     - name: Setup Infra and Run spec tests
       run: make docker/test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,39 @@
 .kitchen.local.yml
 .env
 .env*
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test/verify: test/create
 test/clean:
 	kitchen destroy || true
 	rm -rf .kitchen/* || true
-	aws logs delete-log-group --log-group-name /aws/lambda/spec-test-$(PROVIDER)-$(USER) || true
+	aws logs delete-log-group --log-group-name /aws/lambda/$(PROVIDER)-$(USER) || true
 
 .PHONY: check_aws_quota
 check_aws_quota:

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.14.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:KjsjWBIOb+WQRSEaQex2KGwlmCG+SrAUcLKXoH0actE=",
+    "zh:03b80869b97dfca4ce6ee94a005e15ccec4d98af0876084a963963b05c9ab743",
+    "zh:11d148800fe028fcd10590f0473c5df306e220776e359aa838c2f07e5a89187e",
+    "zh:15d696cf583dc2917b257891e4a33afe7c3e8f20b63183f510267d709baaaf3d",
+    "zh:34c41e44534fbbf95a5f89b38404ee52b41c6c70af68f7e63a423b276fbcf797",
+    "zh:4211d0fd4753f7ba202f3e4a8afb2e03d12112dd4db4f9267c472bd597dc71ca",
+    "zh:47b6017d0cdd2f62b9e46137de38cd618441f658f8570a8e2687cce7643bf953",
+    "zh:51785b942d6f588825f4bfa86e05502be8721194b289c474121072e49acff6c3",
+    "zh:565f76885d41ecfea192b8a2e2f3d4b3dd278790d1d82b204706ae3582d51cf6",
+    "zh:703d670e1d73360d2533b02dbe9e2e055bf6f36a478cd4d66f2349861575c2ed",
+    "zh:7e4701f38590c22066da90b75dd92d81a685225d2d222d22425b7ccb26e92b4a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ca3449252d70df14ad713d5b95fa0610da8087f12c9deb87beffe788f518d06d",
+    "zh:e2ed3d6d8c12d3fe56fb03fe272779270a92f6157ade8c3db1c987b83b62e68c",
+    "zh:f0b07b84a43d1afc3a9790ca699771970525c132fa8551e7b326d1f263414dd1",
+    "zh:f1d83b3e5a29bae471f9841a4e0153eac5bccedbdece369e2f6186e9044db64e",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.34.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:cqONWwrmsDhf8bqHcSXeN08DOrSxU6yoGYiKTVXh9SA=",
+    "zh:1f7405d5b29f6c2c76742abf254a13ce553f72c5abd2c5533d0581b4ad4ab794",
+    "zh:340e9ae09768075c8057c24f4ecf67b429317b59a4c78f99f30a67c8ced255ed",
+    "zh:369e7933336216bb32a4220698816c9eb5b1a0a20950f0649368bbd791ab457e",
+    "zh:59917a578a4a9b50657e955382c05222d5bda37f6005b7e78c20a2f91fe17f31",
+    "zh:59c4d187bfd110ccfdd42a5ce82231d53e24631b1e5602a61010bde7a0b696b1",
+    "zh:736a4a17b30598642d1ff556fe5c27ac61bf48bf887db2a2e5d846430f37b3f6",
+    "zh:98fdd5ff17c6262da479c0f5d731f08e5fd9d77188bf5615d07e4e5c76c02bfc",
+    "zh:9fb457920e67984cb00dc505d1eb9d4eb37ca064ce9efb2e36b67e130465a8f6",
+    "zh:c81500212f716b3c2e5c6cbe9438ce8edeb2051b67a0ffed69b5a29206262187",
+    "zh:dd054762bb339b20addde1d2a1326b0efaf0c15ae80fa84c670934c46bd0dca8",
+    "zh:e0989f0c22f316156bc63aef19ad97969633407b743246d9804afba261fbff34",
+    "zh:e7e53b541e551723274cdf8068b89c237ea0f73a6d717aaa67656813df2d7ccf",
+    "zh:f5acfddba8a8a67fae8522c944e90df61e27249853a65feb93dcc1279a70647a",
+    "zh:f65da46b612049dd8354ba52f3a94b9f7fdc170bee7ca6922b008c54f09c652b",
+  ]
+}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,67 @@
+# CloudFormation AWS Collection Infrastructure
+
+This directory contains a Terraform module responsible for setting up the necessary infrastructure to allow GitHub Actions to release CloudFormation templates to an S3 bucket using OIDC for authentication. This ensures a seamless integration between the CI/CD pipeline and AWS services.
+
+## Usage
+
+Changes to this module are not automatically applied. After merging changes, you should manually apply them.
+
+### Requirements
+
+- **AWS Credentials**: Ensure that you have AWS credentials set up with permissions to create IAM roles, OIDC providers, and manage the specified S3 bucket.
+  
+- **GitHub Access Token**: Set the `GITHUB_TOKEN` environment variable to a GitHub access token with at least the `repo` scope. This token should also have permission to set repository secrets.
+
+### Setup
+
+1. Initialize the Terraform directory:
+   
+   ```bash
+   terraform init
+   ```
+
+2. Verify your AWS identity to ensure you're acting as the expected user or role:
+
+   ```bash
+   aws sts get-caller-identity
+   ```
+
+   Check the output to ensure your ARN and account match your expectations.
+
+3. Plan your Terraform changes:
+
+   ```bash
+   terraform plan -out=tfplan
+   ```
+
+   Review the plan to see what changes will be made. Make sure everything aligns with your intentions.
+
+4. Apply the Terraform changes:
+
+   ```bash
+   terraform apply tfplan
+   ```
+
+   If everything looks correct, approve the changes to apply them.
+
+### Destroy
+
+To tear down the resources created by this module (use with caution):
+
+```bash
+terraform destroy
+```
+
+## Contents
+
+### GitHub Actions Integration
+
+- Sets up an OIDC provider in AWS to allow GitHub Actions to authenticate.
+  
+- Creates an IAM role with permissions that allow GitHub Actions to release CloudFormation templates to the specified S3 bucket.
+
+- Configures GitHub Actions variables in the repository with the ARN of the IAM role so that it can be used.
+
+### S3 Bucket Management
+
+- Grants necessary permissions to the IAM role to read from and write to the specified S3 bucket.

--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "observe-github-tf-state"
+    region = "us-west-2"
+    key    = "github.com/observeinc/aws-test-kitchen"
+  }
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,57 @@
+locals {
+  organization = "hutchic-observe-meta"
+  repository   = "aws-test-kitchen"
+}
+
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  oidc_claim_prefix = trimprefix(data.aws_iam_openid_connect_provider.github_actions.url, "https://")
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.oidc_claim_prefix}:sub"
+      values   = ["repo:${local.organization}/${local.repository}:*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_claim_prefix}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_release" {
+  name = "${local.repository}-gha-release"
+
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+
+  tags = {
+    Principal  = "GitHub Actions"
+    Repository = "${local.organization}/${local.repository}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "admin_policy_attachment" {
+  role       = aws_iam_role.github_actions_release.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "github_actions_secret" "aws_release_role" {
+  repository      = local.repository
+  secret_name     = "AWS_ROLE_ARN"
+  plaintext_value = aws_iam_role.github_actions_release.arn
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,5 @@
 locals {
-  organization = "hutchic-observe-meta"
+  organization = "observeinc"
   repository   = "aws-test-kitchen"
 }
 

--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -1,0 +1,3 @@
+provider "github" {
+  owner = local.organization
+}

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
* feat(aws): terraform to provision a federated role and save it as a github variable
* feat(gha): swap static AWS IAM credentials with federated credentials
* fix(cleanup): adjust the manual log group cleanup to match the new naming convention

This PR is coming from my [fork](https://github.com/hutchic-observe-meta/aws-test-kitchen/pull/1) because that's where I tested this. Necessary steps before merging
- [x] manually setting up AWS <-> github OIDC federation
- [x] manually setup a s3 bucket for the terraform state
- [x] run the infrastructure terraform