### PR TITLE
fix(ci): include a git fetch as part of munging the submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,14 @@ jobs:
       if: matrix.provider == 'terraform' && inputs.code_sha != ''
       run: |
         cd terraform-aws-collection
+        git fetch
         git checkout ${{ inputs.code_sha }}
       
     - name: Checkout CloudFormation SHA
       if: matrix.provider == 'cloudformation' && inputs.code_sha != ''
       run: |
         cd cloudformation-aws-collection
+        git fetch
         git checkout ${{ inputs.code_sha }}
     
     - name: Login to GitHub Container Registry


### PR DESCRIPTION
To resolve
```
Run cd cloudformation-aws-collection
  cd cloudformation-aws-collection
  git checkout ca54dda7bf4d581805cd0e8f6c081891a1dd3c67
  shell: /usr/bin/bash -e {0}
  env:
    USER: gha-6[2](https://github.com/observeinc/cloudformation-aws-collection/actions/runs/6226180605/job/16898371244#step:4:2)26180605
    AWS_TEST_KITCHEN_REPO: aws-test-kitchen
    OBSERVE_CUSTOMER: ***
    OBSERVE_TOKEN: ***
    OBSERVE_DOMAIN: ***
    IMAGE_NAME: ghcr.io/observeinc/aws-test-kitchen:main
fatal: reference is not a tree: ca54dda7bf4d581805cd0e8f6c081891a1dd[3](https://github.com/observeinc/cloudformation-aws-collection/actions/runs/6226180605/job/16898371244#step:4:3)c[6](https://github.com/observeinc/cloudformation-aws-collection/actions/runs/6226180605/job/16898371244#step:4:6)[7](https://github.com/observeinc/cloudformation-aws-collection/actions/runs/6226180605/job/16898371244#step:4:7)
Error: Process completed with exit code 12[8](https://github.com/observeinc/cloudformation-aws-collection/actions/runs/6226180605/job/16898371244#step:4:8).
```