### PR TITLE
chore(ci): migrate away from arn role to access_key / secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ on:
         required: true
       OBSERVE_DOMAIN:
         required: false
-      AWS_ROLE_ARN:
+      AWS_ACCESS_KEY_ID:
         required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true      
   workflow_dispatch:
     inputs:
       test_type:


### PR DESCRIPTION
Migrating away from a single statically provisioned AWS account to ephemeral accounts that use [dce](https://github.com/Optum/dce) (disposable cloud environments) means we have statically provisioned aws access key / secret.

Eventually we'll use a access role arn again but with the ephemeral accounts but in the meantime need to fix the existing credentials